### PR TITLE
Oauth2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 /contrib/bootstrap-login-form/.nrepl-port
 /contrib/bootstrap-login-form/target/repl-port
 /contrib/bootstrap-login-form/target/stale/extract-native.dependencies
+*.DS_Store

--- a/src/cylon/oauth/application_registry.clj
+++ b/src/cylon/oauth/application_registry.clj
@@ -1,0 +1,30 @@
+(ns cylon.oauth.application-registry
+  (:require
+   [schema.core :as s]))
+
+(defprotocol ApplicationRegistry
+  (register-application [_ properties])
+  (lookup-application [_ client-id]))
+
+(s/defn register-application+ :- {:client-id s/Str
+                                  :client-secret s/Str}
+  [p :- (s/protocol ApplicationRegistry)
+   ;; If client-id and/or client-secret are not specified, they will be
+   ;; generated.
+   properties :- {(s/optional-key :client-id) s/Str
+                  (s/optional-key :client-secret) s/Str
+                  :application-name s/Str
+                  :homepage-uri s/Str
+                  (s/optional-key :description) s/Str
+                  :callback-uri s/Str}]
+  (register-application p properties))
+
+(s/defn lookup-application+ :- {:application-name s/Str
+                                :homepage-uri s/Str
+                                (s/optional-key :description) s/Str
+                                :callback-uri s/Str
+                                :client-id s/Str
+                                :client-secret s/Str}
+  [p :- (s/protocol ApplicationRegistry)
+   client-id :- s/Str]
+  (lookup-application p client-id))

--- a/src/cylon/oauth/impl/application_registry.clj
+++ b/src/cylon/oauth/impl/application_registry.clj
@@ -1,0 +1,30 @@
+(ns cylon.oauth.impl.application-registry
+  (require    [com.stuartsierra.component :as component]
+              [cylon.oauth.application-registry :refer (ApplicationRegistry)]))
+
+;; Optional ApplicationRegistry implementation
+
+(defrecord RefBackedApplicationRegistry []
+  component/Lifecycle
+  (start [this]
+    (assoc this :store {:last-client-id (ref 1000)
+                        :applications (ref {})}))
+  (stop [this] this)
+
+  ApplicationRegistry
+  (register-application [this properties]
+    (dosync
+     (let [client-id (or (:client-id properties)
+                         (str (alter (-> this :store :last-client-id) inc)))
+           properties (assoc properties
+                        :client-id client-id
+                        :client-secret (or (:client-secret properties)
+                                           (str (java.util.UUID/randomUUID))))]
+       (alter (-> this :store :applications) assoc client-id properties)
+       (select-keys properties [:client-id :client-secret]))))
+
+  (lookup-application [this client-id]
+    (-> this :store :applications deref (get client-id))))
+
+(defn new-ref-backed-application-registry []
+  (->RefBackedApplicationRegistry))

--- a/src/cylon/oauth/impl/authorizer.clj
+++ b/src/cylon/oauth/impl/authorizer.clj
@@ -1,0 +1,28 @@
+(ns cylon.oauth.impl.authorizer
+  (require [com.stuartsierra.component :as component]
+           [clojure.tools.logging :refer :all]
+           [cylon.authorization :refer (Authorizer)]
+           [cylon.session :refer (get-session)]
+           [cylon.oauth.scopes :refer (valid-scope?)]))
+
+;; renamed from OAuth2AccessTokenAuthorizer to OAuth2Authorizer
+;; because I still don't know/find another way to authorize in oauth2 spec
+
+(defrecord OAuth2Authorizer []
+  Authorizer
+  (authorized? [this request scope]
+    (if (valid-scope? (:auth-server this) scope)
+      (when-let [auth-header (get (:headers request) "authorization")]
+
+        (let [access-token (second (re-matches #"\Qtoken\E\s+(.*)" auth-header))
+              session (get-session (:access-token-store this) access-token)
+              scopes (:scopes session)]
+          (infof "session is %s, scopes is %s" session scopes)
+          (when session
+            (when scopes (scopes scope)))))
+
+      ;; Not a valid scope - (internal error)
+      (throw (ex-info "Not a valid scope!" {:scope scope})))))
+
+(defn new-oauth2-authorizer [& {:as opts}]
+  (component/using (->OAuth2Authorizer) [:access-token-store :auth-server]))

--- a/src/cylon/oauth/impl/client_authorizer_webapp.clj
+++ b/src/cylon/oauth/impl/client_authorizer_webapp.clj
@@ -1,57 +1,23 @@
-(ns cylon.impl.oauth2
-  (:require
-   [com.stuartsierra.component :as component]
-   [clojure.tools.logging :refer :all]
-   [clojure.java.io :as io]
-   [clojure.string :as str]
-   [hiccup.core :refer (html h)]
-   [modular.bidi :refer (WebService)]
-   [bidi.bidi :refer (path-for)]
-   [ring.middleware.params :refer (wrap-params)]
-   [org.httpkit.client :refer (request) :rename {request http-request}]
-   [cheshire.core :refer (encode decode-stream)]
-   [cylon.authorization :refer (Authorizer)]
-   [ring.middleware.cookies :refer (wrap-cookies cookies-request cookies-response)]
-   [ring.util.codec :refer (url-encode)]
-   [schema.core :as s]
-   [cylon.user :refer (verify-user)]
-   [cylon.session :refer (create-session! assoc-session! ->cookie get-session-value get-cookie-value get-session)]
-   [cylon.totp :refer (OneTimePasswordStore get-totp-secret totp-token)]
-   [clj-jwt.core :refer (to-str jwt sign str->jwt verify encoded-claims)]
-   [clj-time.core :refer (now plus days)]
-   ))
+(ns cylon.oauth.impl.client-authorizer-webapp
+  (require [com.stuartsierra.component :as component]
+           [clojure.tools.logging :refer :all]
+           [cylon.oauth.scopes :refer (Scopes) ]
+           [modular.bidi :refer (WebService)]
+           [bidi.bidi :refer (path-for)]
+           [hiccup.core :refer (html h)]
+           [schema.core :as s]
+           [clojure.string :as str]
+           [cylon.oauth.application-registry :refer ( lookup-application+)]
+           [cylon.user :refer (verify-user)]
+           [cylon.totp :refer (OneTimePasswordStore get-totp-secret totp-token)]
+           [clj-time.core :refer (now plus days)]
+           [cheshire.core :refer (encode)]
+           [clj-jwt.core :refer (to-str sign jwt)]
+           [ring.middleware.params :refer (wrap-params)]
+           [cylon.session :refer (create-session! assoc-session! ->cookie get-session-value get-cookie-value get-session)]
+           [ring.middleware.cookies :refer (wrap-cookies cookies-request cookies-response)]))
 
-(defprotocol Scopes
-  (valid-scope? [_ scope]))
-
-(defprotocol ApplicationRegistry
-  (register-application [_ properties])
-  (lookup-application [_ client-id]))
-
-(s/defn register-application+ :- {:client-id s/Str
-                                  :client-secret s/Str}
-  [p :- (s/protocol ApplicationRegistry)
-   ;; If client-id and/or client-secret are not specified, they will be
-   ;; generated.
-   properties :- {(s/optional-key :client-id) s/Str
-                  (s/optional-key :client-secret) s/Str
-                  :application-name s/Str
-                  :homepage-uri s/Str
-                  (s/optional-key :description) s/Str
-                  :callback-uri s/Str}]
-  (register-application p properties))
-
-(s/defn lookup-application+ :- {:application-name s/Str
-                                :homepage-uri s/Str
-                                (s/optional-key :description) s/Str
-                                :callback-uri s/Str
-                                :client-id s/Str
-                                :client-secret s/Str}
-  [p :- (s/protocol ApplicationRegistry)
-   client-id :- s/Str]
-  (lookup-application p client-id))
-
-(defrecord AuthServer [store scopes iss]
+(defrecord ClientAuthorizerWebApp [store scopes iss]
   Scopes
   (valid-scope? [_ scope] (contains? scopes scope))
 
@@ -281,7 +247,7 @@
 
   (uri-context [this] "/login/oauth"))
 
-(defn new-auth-server [& {:as opts}]
+(defn new-client-authorizer-webapp [& {:as opts}]
   (component/using
    (->> opts
         (merge {:store (atom {})})
@@ -289,220 +255,8 @@
                      :store s/Any
                      :iss s/Str ; uri actually, see openid-connect ch 2.
                      })
-        map->AuthServer)
+        map->ClientAuthorizerWebApp)
    [:access-token-store
     :session-store
     :user-domain
     :application-registry]))
-
-;; --------
-
-(defprotocol TempState
-  (expect-state [_ state])
-  (expecting-state? [this state]))
-
-(defrecord Application [store access-token-uri]
-  component/Lifecycle
-  (start [this]
-    ;; If there's an :application-registry dependency, use it to
-    ;; register this app.
-    (if-let [reg (:application-registry this)]
-      (let [{:keys [client-id client-secret]}
-            (s/with-fn-validation
-              (register-application+
-               reg
-               (select-keys this [:client-id
-                                  :client-secret
-                                  :application-name
-                                  :homepage-uri
-                                  :description
-                                  :callback-uri])))]
-        ;; In case these are generated
-        (assoc this :client-id client-id :client-secret client-secret))
-
-      ;; If no app registry, make sure we can standalone as an app.
-      (s/validate {:client-id s/Str
-                   :client-secret s/Str
-                   s/Keyword s/Any} this)))
-  (stop [this] this)
-
-  WebService
-  (request-handlers [this]
-    {::grant
-     (->
-      (fn [req]
-        (let [params (:query-params req)
-              state (get params "state")]
-
-          (if (not (expecting-state? this state))
-            {:status 400 :body "Unexpected user state"}
-
-            ;; otherwise
-            (let [code (get params "code")
-
-                  ;; Exchange the code for an access token
-                  at-resp
-                  @(http-request
-                    {:method :post
-                     :url access-token-uri
-                     :headers {"content-type" "application/x-www-form-urlencoded"}
-                     ;; Exchange the code for an access token - application/x-www-form-urlencoded format
-
-                     ;; TODO: From reading OAuth2 4.1.2 I
-                     ;; don't think we should use client_id -
-                     ;; that looks to be a github thing.
-
-                     :body (format "client_id=%s&client_secret=%s&code=%s"
-                                   (:client-id this) (:client-secret this) code)}
-                    #(if (:error %)
-                       %
-                       (update-in % [:body] (comp decode-stream io/reader))))]
-
-              (if-let [error (:error at-resp)]
-                {:status 403
-                 :body (format "Something went wrong: status of underlying request, error was %s"
-                               error)
-                 }
-                (if (not= (:status at-resp) 200)
-                  {:status 403
-                   :body (format "Something went wrong: status of underlying request %s" (:status at-resp))}
-
-
-                  (let [app-session-id (-> req cookies-request :cookies (get "app-session-id") :value)
-                        original-uri (:original-uri (get-session (:session-store this) app-session-id))
-                        access-token (get (:body at-resp) "access_token")
-                        id-token (-> (get (:body at-resp) "id_token") str->jwt)
-                        ]
-                    (if (verify id-token "secret")
-                      (do
-                        (infof "Verified id_token: %s" id-token)
-                        (assert original-uri (str "Failed to get original-uri from session " app-session-id))
-                        (assoc-session! (:session-store this) app-session-id :access-token access-token)
-                        (infof "Claims are %s" (:claims id-token))
-                        (assoc-session! (:session-store this) app-session-id :cylon/identity (-> id-token :claims :sub))
-
-                        {:status 302
-                         :headers {"Location" original-uri}
-                         :body (str "Logged in, and we got an access token: " (:body at-resp))
-
-                         })
-                      ;; Error response - id_token failed verification
-                      ))))))))
-      wrap-params wrap-cookies)})
-  (routes [this] ["/grant" {:get ::grant}])
-  (uri-context [this] "/oauth")
-
-  Authorizer
-  ;; Return the access-token, if you can!
-  (authorized? [this req scope]
-    (let [app-session-id (-> req cookies-request :cookies (get "app-session-id") :value)]
-      (select-keys (get-session (:session-store this) app-session-id) [:access-token :cylon/identity])))
-
-  ;; TODO Deprecate this!
-  TempState
-  (expect-state [this state]
-    (swap! store update-in [:expected-states] conj state))
-  (expecting-state? [this state]
-    (if (contains? (:expected-states @store) state)
-      (do
-        (swap! store update-in [:expected-states] disj state)
-        true))))
-
-(defn new-application
-  "Represents an OAuth2 application. This component provides all the web
-  routes necessary to provide signup, login and password resets. It also
-  acts as an Authorizer, which returns an OAuth2 access token from a
-  call to authorized?"
-  [& {:as opts}]
-  (component/using
-   (->> opts
-        (merge {:store (atom {:expected-states #{}})})
-        (s/validate {(s/optional-key :client-id) s/Str
-                     (s/optional-key :client-secret) s/Str
-                     :application-name s/Str
-                     :homepage-uri s/Str
-                     :callback-uri s/Str
-
-                     :required-scopes #{s/Keyword}
-                     :store s/Any
-
-                     :authorize-uri s/Str
-                     :access-token-uri s/Str
-                     })
-        map->Application)
-   [:session-store :application-registry]))
-
-(defn authorize [app req]
-  (let [original-uri (apply format "%s://%s%s" ((juxt (comp name :scheme) (comp #(get % "host") :headers) :uri) req))
-        ;; We need a session to store the original uri
-        session (create-session!
-                 (:session-store app)
-                 {:original-uri original-uri})
-        state (str (java.util.UUID/randomUUID))]
-
-    (expect-state app state)
-    (cookies-response
-     {:status 302
-      :headers {"Location"
-                (format "%s?client_id=%s&state=%s&scope=%s"
-                        (:authorize-uri app)
-                        ;;
-                        (:client-id app)
-                        state
-                        (url-encode "openid profile email")
-                        )}
-      :cookies {"app-session-id"
-                {:value (:cylon.session/key session)
-                 :expires (.toGMTString
-                           (doto (new java.util.Date)
-                             (.setTime (:cylon.session/expiry session))
-                             ))}}})))
-
-
-
-(defrecord OAuth2AccessTokenAuthorizer []
-  Authorizer
-  (authorized? [this request scope]
-    (if (valid-scope? (:auth-server this) scope)
-      (when-let [auth-header (get (:headers request) "authorization")]
-
-        (let [access-token (second (re-matches #"\Qtoken\E\s+(.*)" auth-header))
-              session (get-session (:access-token-store this) access-token)
-              scopes (:scopes session)]
-          (infof "session is %s, scopes is %s" session scopes)
-          (when session
-            (when scopes (scopes scope))
-            )))
-
-      ;; Not a valid scope - (internal error)
-      (throw (ex-info "Not a valid scope!" {:scope scope})))))
-
-(defn new-oauth2-access-token-authorizer [& {:as opts}]
-  (component/using (->OAuth2AccessTokenAuthorizer) [:access-token-store :auth-server]))
-
-;; Optional ApplicationRegistry implementation
-
-(defrecord RefBackedApplicationRegistry []
-  component/Lifecycle
-  (start [this]
-    (assoc this :store {:last-client-id (ref 1000)
-                        :applications (ref {})}))
-  (stop [this] this)
-
-  ApplicationRegistry
-  (register-application [this properties]
-    (dosync
-     (let [client-id (or (:client-id properties)
-                         (str (alter (-> this :store :last-client-id) inc)))
-           properties (assoc properties
-                        :client-id client-id
-                        :client-secret (or (:client-secret properties)
-                                           (str (java.util.UUID/randomUUID))))]
-       (alter (-> this :store :applications) assoc client-id properties)
-       (select-keys properties [:client-id :client-secret]))))
-
-  (lookup-application [this client-id]
-    (-> this :store :applications deref (get client-id))))
-
-(defn new-ref-backed-application-registry []
-  (->RefBackedApplicationRegistry))

--- a/src/cylon/oauth/impl/oauth_client.clj
+++ b/src/cylon/oauth/impl/oauth_client.clj
@@ -1,0 +1,179 @@
+(ns cylon.oauth.impl.oauth-client
+  (require [com.stuartsierra.component :as component]
+           [clojure.tools.logging :refer :all]
+           [schema.core :as s]
+           [modular.bidi :refer (WebService)]
+           [cylon.authorization :refer (Authorizer)]
+           [cylon.session :refer (get-session assoc-session! create-session!)]
+           [ring.middleware.cookies :refer (wrap-cookies cookies-request cookies-response)]
+           [ring.util.codec :refer (url-encode)]
+           [ring.middleware.params :refer (wrap-params)]
+           [org.httpkit.client :refer (request) :rename {request http-request}]
+           [cheshire.core :refer (encode decode-stream)]
+           [cylon.oauth.application-registry :refer (register-application+)]
+           [clojure.java.io :as io]
+           [clj-jwt.core :refer (to-str jwt sign str->jwt verify encoded-claims)]
+           ))
+
+;; --------
+
+(defprotocol TempState
+  (expect-state [_ state])
+  (expecting-state? [this state]))
+
+(defrecord OAuthClient [store access-token-uri]
+  component/Lifecycle
+  (start [this]
+    ;; If there's an :application-registry dependency, use it to
+    ;; register this app.
+    (if-let [reg (:application-registry this)]
+      (let [{:keys [client-id client-secret]}
+            (s/with-fn-validation
+              (register-application+
+               reg
+               (select-keys this [:client-id
+                                  :client-secret
+                                  :application-name
+                                  :homepage-uri
+                                  :description
+                                  :callback-uri])))]
+        ;; In case these are generated
+        (assoc this :client-id client-id :client-secret client-secret))
+
+      ;; If no app registry, make sure we can standalone as an app.
+      (s/validate {:client-id s/Str
+                   :client-secret s/Str
+                   s/Keyword s/Any} this)))
+  (stop [this] this)
+
+  WebService
+  (request-handlers [this]
+    {::grant
+     (->
+      (fn [req]
+        (let [params (:query-params req)
+              state (get params "state")]
+
+          (if (not (expecting-state? this state))
+            {:status 400 :body "Unexpected user state"}
+
+            ;; otherwise
+            (let [code (get params "code")
+
+                  ;; Exchange the code for an access token
+                  at-resp
+                  @(http-request
+                    {:method :post
+                     :url access-token-uri
+                     :headers {"content-type" "application/x-www-form-urlencoded"}
+                     ;; Exchange the code for an access token - application/x-www-form-urlencoded format
+
+                     ;; TODO: From reading OAuth2 4.1.2 I
+                     ;; don't think we should use client_id -
+                     ;; that looks to be a github thing.
+
+                     :body (format "client_id=%s&client_secret=%s&code=%s"
+                                   (:client-id this) (:client-secret this) code)}
+                    #(if (:error %)
+                       %
+                       (update-in % [:body] (comp decode-stream io/reader))))]
+
+              (if-let [error (:error at-resp)]
+                {:status 403
+                 :body (format "Something went wrong: status of underlying request, error was %s"
+                               error)
+                 }
+                (if (not= (:status at-resp) 200)
+                  {:status 403
+                   :body (format "Something went wrong: status of underlying request %s" (:status at-resp))}
+
+
+                  (let [app-session-id (-> req cookies-request :cookies (get "app-session-id") :value)
+                        original-uri (:original-uri (get-session (:session-store this) app-session-id))
+                        access-token (get (:body at-resp) "access_token")
+                        id-token (-> (get (:body at-resp) "id_token") str->jwt)
+                        ]
+                    (if (verify id-token "secret")
+                      (do
+                        (infof "Verified id_token: %s" id-token)
+                        (assert original-uri (str "Failed to get original-uri from session " app-session-id))
+                        (assoc-session! (:session-store this) app-session-id :access-token access-token)
+                        (infof "Claims are %s" (:claims id-token))
+                        (assoc-session! (:session-store this) app-session-id :cylon/identity (-> id-token :claims :sub))
+
+                        {:status 302
+                         :headers {"Location" original-uri}
+                         :body (str "Logged in, and we got an access token: " (:body at-resp))
+
+                         })
+                      ;; Error response - id_token failed verification
+                      ))))))))
+      wrap-params wrap-cookies)})
+  (routes [this] ["/grant" {:get ::grant}])
+  (uri-context [this] "/oauth")
+
+  Authorizer
+  ;; Return the access-token, if you can!
+  (authorized? [this req scope]
+    (let [app-session-id (-> req cookies-request :cookies (get "app-session-id") :value)]
+      (select-keys (get-session (:session-store this) app-session-id) [:access-token :cylon/identity])))
+
+  ;; TODO Deprecate this!
+  TempState
+  (expect-state [this state]
+    (swap! store update-in [:expected-states] conj state))
+  (expecting-state? [this state]
+    (if (contains? (:expected-states @store) state)
+      (do
+        (swap! store update-in [:expected-states] disj state)
+        true))))
+
+(defn new-oauth-client
+  "Represents an OAuth2 application. This component provides all the web
+  routes necessary to provide signup, login and password resets. It also
+  acts as an Authorizer, which returns an OAuth2 access token from a
+  call to authorized?"
+  [& {:as opts}]
+  (component/using
+   (->> opts
+        (merge {:store (atom {:expected-states #{}})})
+        (s/validate {(s/optional-key :client-id) s/Str
+                     (s/optional-key :client-secret) s/Str
+                     :application-name s/Str
+                     :homepage-uri s/Str
+                     :callback-uri s/Str
+
+                     :required-scopes #{s/Keyword}
+                     :store s/Any
+
+                     :authorize-uri s/Str
+                     :access-token-uri s/Str
+                     })
+        map->OAuthClient)
+   [:session-store :application-registry]))
+
+(defn authorize [app req]
+  (let [original-uri (apply format "%s://%s%s" ((juxt (comp name :scheme) (comp #(get % "host") :headers) :uri) req))
+        ;; We need a session to store the original uri
+        session (create-session!
+                 (:session-store app)
+                 {:original-uri original-uri})
+        state (str (java.util.UUID/randomUUID))]
+
+    (expect-state app state)
+    (cookies-response
+     {:status 302
+      :headers {"Location"
+                (format "%s?client_id=%s&state=%s&scope=%s"
+                        (:authorize-uri app)
+                        ;;
+                        (:client-id app)
+                        state
+                        (url-encode "openid profile email")
+                        )}
+      :cookies {"app-session-id"
+                {:value (:cylon.session/key session)
+                 :expires (.toGMTString
+                           (doto (new java.util.Date)
+                             (.setTime (:cylon.session/expiry session))
+                             ))}}})))

--- a/src/cylon/oauth/scopes.clj
+++ b/src/cylon/oauth/scopes.clj
@@ -1,0 +1,4 @@
+(ns cylon.oauth.scopes)
+
+(defprotocol Scopes
+  (valid-scope? [_ scope]))


### PR DESCRIPTION
Mainly, this pull request separates `oauth2.clj` in differentes files/namespaces into folder `cylon/oauth/`

Also it renames App for Client because it's the relation of Server-Client is less ambiguous than Server-App

It renames the AuthServer component for ClientAuthorizerWebApp

Only rest one naming related "thing" that doesn't seem to work yet: the oauth-authorizer has the old named dependency "auth-server" and currently is being injected "ClientAuthorizerWebApp"
