### PR TITLE
Add CSRF option validation cookie-to-header

### DIFF
--- a/src/cylon/impl/session.clj
+++ b/src/cylon/impl/session.clj
@@ -12,20 +12,24 @@
    [modular.ring :refer (WebRequestMiddleware WebRequestBinding)]
    [schema.core :as s]))
 
-(defrecord CookieAuthenticator []
+(defrecord CookieAuthenticator [check-csrf-cookie-to-header?]
   Authenticator
   (authenticate [this request]
     (tracef "Authenticating with cookie: %s" (:uri request))
     (when-let [cookie-val (-> request cookies-request :cookies (get "session-id") :value)]
       (tracef "Authenticating %s with cookie value of %s" (:uri request) cookie-val)
 
-      (when-let [session (get-session (:session-store this) cookie-val)]
-        (tracef "Found session, user is %s" (:username session))
-        {:session session  ; retain compatibility with Ring's wrap-session
-         :cylon/session-id cookie-val
-         :cylon/session session
-         :cylon/identity (:identity session)
-         :cylon/authentication-method :cookie})))
+      (let [ring-session {:session session ; retain compatibility with Ring's wrap-session
+                            :cylon/session-id cookie-val
+                            :cylon/session session
+                            :cylon/user (:username session)
+                            :cylon/authentication-method :cookie}]
+          (println check-csrf-cookie-to-header? ring-session (get (:headers request) "x-csrf-token"))
+          (if check-csrf-cookie-to-header?
+            (if (= cookie-val (get (:headers request) "x-csrf-token"))
+              ring-session
+              (tracef "CSRF cookie-to-header invalid %s" (get (:headers request) "x-csrf-token")))
+            ring-session))))
 
   WebRequestMiddleware
   (request-middleware [this]
@@ -43,6 +47,7 @@
 (defn new-cookie-authenticator [& {:as opts}]
   (component/using
    (->> opts
+        (merge {:check-csrf-cookie-to-header? false})
         map->CookieAuthenticator)
    [:session-store]))
 


### PR DESCRIPTION
Checking CSRF attempt using javascript same origin policy security feature

http://en.wikipedia.org/wiki/Cross-site_request_forgery#Cookie-to-Header_Token

Default value is false
