### PR TITLE
0.3.2 Add CSRF option validation cookie-to-header

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 ;; Copyright © 2014 JUXT LTD.
 
-(defproject cylon "0.3.1"
+(defproject cylon "0.3.2"
   :description "An integrated security system for applications built on component"
   :url "https://github.com/juxt/cylon"
   :license {:name "The MIT License"

--- a/src/cylon/impl/login_form.clj
+++ b/src/cylon/impl/login_form.clj
@@ -88,12 +88,11 @@
      (:value (get cookies "session-id")))
     {:status 302 :headers {"Location" "/"}}))
 
-(defrecord LoginForm [uri-context renderer middleware fields uid]
+(defrecord LoginForm [uri-context renderer middleware fields uid requested-uri]
   WebService
   (request-handlers [this]
     {:login
-     (let [f (fn [{{{requested-uri :value} "requested-uri"
-                    {login-status :value} "login-status"
+     (let [f (fn [{{{login-status :value} "login-status"
                     {uid-value :value} "uid"} :cookies
                     routes :modular.bidi/routes :as request}]
                {:status 200
@@ -139,12 +138,14 @@
                               (s/required-key :type) s/Str
                               (s/optional-key :label) s/Str
                               (s/optional-key :placeholder) s/Str
-                              (s/optional-key :required) s/Bool}]})
+                              (s/optional-key :required) s/Bool}]
+   (s/optional-key :requested-uri) s/Str})
 
 (defn new-login-form [& {:as opts}]
   (component/using
    (->> opts
         (merge {:uri-context ""
+                :requested-uri "/"
                 ;; If you don't provide a renderer, one will be provided for you
                 :renderer (->PlainLoginFormRenderer)
                 :fields

--- a/src/cylon/impl/session.clj
+++ b/src/cylon/impl/session.clj
@@ -12,7 +12,7 @@
    [modular.ring :refer (WebRequestMiddleware WebRequestBinding)]
    [schema.core :as s]))
 
-(defrecord CookieAuthenticator []
+(defrecord CookieAuthenticator [check-csrf-cookie-to-header?]
   Authenticator
   (authenticate [this request]
     (tracef "Authenticating with cookie: %s" (:uri request))


### PR DESCRIPTION
Checking CSRF attempt using javascript same origin policy security feature

http://en.wikipedia.org/wiki/Cross-site_request_forgery#Cookie-to-Header_Token

Default value is false
